### PR TITLE
Add time range overrides, including per-schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ The configuration must be a `.yml` file (specified by the `--config` flag) with 
 # PagerDuty auth token
 pdAuthToken: 12345
 
+# Explicitly set report time range (RFC822)
+reportTimeRange:
+  start: 01 Jan 20 00:00 UTC
+  end: 01 Feb 20 00:00 UTC
+
 # Rotation general information
 rotationInfo:
   dailyRotationStartsAt: 8
@@ -94,6 +99,12 @@ rotationUsers:
   - name: "Roger Solé"
     holidaysCalendar: sp_premia
     userId: P33A33B
+
+# Time range overrides on a per-schedule basis (RFC 822)
+scheduleTimeRangeOverrides:
+  - id: ABCDEFG
+    start: 01 Jan 20 00:00 UTC
+    end: 21 Jan 20 00:00 UTC
 
 # List of schedule IDs that can be ignored when generating the report
 schedulesToIgnore:

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -31,13 +31,26 @@ type RotationInfo struct {
 	CheckRotationChangeEvery int
 }
 
+type ReportTimeRange struct {
+	Start string
+	End   string
+}
+
+type ScheduleTimeRange struct {
+	Id    string
+	Start string
+	End   string
+}
+
 type Configuration struct {
-	PdAuthToken           string
-	RotationInfo          RotationInfo
-	RotationExcludedHours []RotationExcludedHoursDay
-	RotationPrices        RotationPrices
-	RotationUsers         []RotationUser
-	SchedulesToIgnore     []string
+	PdAuthToken                string
+	ReportTimeRange            ReportTimeRange
+	RotationInfo               RotationInfo
+	RotationExcludedHours      []RotationExcludedHoursDay
+	RotationPrices             RotationPrices
+	RotationUsers              []RotationUser
+	ScheduleTimeRangeOverrides []ScheduleTimeRange
+	SchedulesToIgnore          []string
 
 	cacheRotationUsers  map[string]*RotationUser
 	cacheRotationPrices map[string]int

--- a/report/console_report.go
+++ b/report/console_report.go
@@ -33,6 +33,7 @@ func (r *consoleReport) GenerateReport(data *PrintableData) (string, error) {
 		fmt.Println(blankLine)
 		fmt.Println(separator)
 		fmt.Println(fmt.Sprintf("| Schedule: '%s' (%s)", scheduleData.Name, scheduleData.ID))
+		fmt.Println(fmt.Sprintf("| Time Range: %s to %s", scheduleData.StartDate.Format(time.RFC822), scheduleData.EndDate.Format(time.RFC822)))
 		fmt.Println(separator)
 		fmt.Println(fmt.Sprintf(rowFormat, "USER", "WEEKDAY", "WEEKEND", "BANK HOLIDAY", "TOTAL WEEKDAY", "TOTAL WEEKEND", "TOTAL BANK HOLIDAY", "TOTAL"))
 		fmt.Println(fmt.Sprintf(rowFormat, "", "HOURS", "HOURS", "HOURS", "AMOUNT", "AMOUNT", "AMOUNT", "AMOUNT"))

--- a/report/csv_report.go
+++ b/report/csv_report.go
@@ -80,6 +80,7 @@ func (r *csvReport) GenerateReport(data *PrintableData) (string, error) {
 func (r *csvReport) writeSingleRotation(scheduleData *ScheduleData, data *PrintableData, header []string) error {
 	fmt.Println(separator)
 	fmt.Println(fmt.Sprintf("| Writing Schedule: '%s' (%s)", scheduleData.Name, scheduleData.ID))
+	fmt.Println(fmt.Sprintf("| Time Range: %s to %s", scheduleData.StartDate.Format(time.RFC822), scheduleData.EndDate.Format(time.RFC822)))
 	fmt.Println(separator)
 	noSpaceName := strings.Replace(scheduleData.Name, " ", "_", -1)
 

--- a/report/pdf_report.go
+++ b/report/pdf_report.go
@@ -61,6 +61,11 @@ func (r *pdfReport) GenerateReport(data *PrintableData) (string, error) {
 			"L", 0, "L", false, 0, "")
 		pdf.Ln(8)
 
+		pdf.CellFormat(0, 5,
+			fmt.Sprintf("Time Range: %s to %s", scheduleData.StartDate.Format(time.RFC822), scheduleData.EndDate.Format(time.RFC822)),
+			"L", 0, "L", false, 0, "")
+		pdf.Ln(8)
+
 		pdf.SetFont("Courier", "B", 9)
 		pdf.CellFormat(0, 5,
 			fmt.Sprintf(matrixRowFormat, "USER", "WEEKDAY", "WEEKEND", "B. HOLIDAY", "WEEKDAY", "WEEKEND", "B. HOLIDAY", "TOTAL"),

--- a/report/writer.go
+++ b/report/writer.go
@@ -14,6 +14,8 @@ type PrintableData struct {
 type ScheduleData struct {
 	ID        string
 	Name      string
+	StartDate time.Time
+	EndDate   time.Time
 	RotaUsers []*ScheduleUser
 }
 


### PR DESCRIPTION
This PR:

1. Allows the user to specify a custom report time range
    * Default is still `dailyRotationStartsAt` on the first day of the previous month to `dailyRotationStartsAt` on the first day of the current month.
1. Allows the user to specify a report time range override for specific schedules.
    * Useful in cases such as mid-month schedule switchovers.
1. Tracks the time range per schedule rather than at the report level, allowing these overrides (if set) to trickle through to the final report.

Signed-off-by: Brendan Devenney <brendan.devenney@form3.tech>