### PR TITLE
allowing you to default users not in config to a calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ rotationInfo:
   dailyRotationStartsAt: 8
   checkRotationChangeEvery: 30 # minutes
 
-defaultHolidayCalendar: uk # default calendar to use for users not specified in config, allows you to only define users with different calendars
+defaultHolidayCalendar: uk # default calendar to use for users not specified in config, allows you to only define users with different calendars. If value not specified then fall back to old behaviour
 
 # Rotation excluded hours by day type
 rotationExcludedHours:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ rotationInfo:
   dailyRotationStartsAt: 8
   checkRotationChangeEvery: 30 # minutes
 
+defaultHolidayCalendar: uk # default calendar to use for users not specified in config, allows you to only define users with different calendars
+
 # Rotation excluded hours by day type
 rotationExcludedHours:
   - day: weekday

--- a/_assets/calendars/holidays_calendar.sp_castelldefels_base.2020.yml
+++ b/_assets/calendars/holidays_calendar.sp_castelldefels_base.2020.yml
@@ -1,0 +1,30 @@
+# https://calendarios.ideal.es/laboral/catalunya/barcelona/castelldefels
+---
+- title: "new year"
+  date: 01/01/2020
+- title: "three magic kings"
+  date: 06/01/2020
+- title: "saint friday"
+  date: 10/04/2020
+- title: "easter"
+  date: 13/04/2020
+- title: "may first"
+  date: 01/05/2020
+- title: "Saint Johan"
+  date: 24/06/2020
+- title: "castelldefels day"
+  date: 14/08/2020
+- title: "assumption day"
+  date: 15/08/2020
+- title: "catalonia day"
+  date: 11/09/2020
+- title: "national day"
+  date: 12/10/2020
+- title: "constitution day"
+  date: 07/12/2020
+- title: "day of the immaculate conception"
+  date: 08/12/2020
+- title: "christmas"
+  date: 25/12/2020
+- title: "Staint Steve"
+  date: 26/12/2020

--- a/api/pagerduty.go
+++ b/api/pagerduty.go
@@ -79,6 +79,11 @@ func (p *PagerDutyClient) ListUsers() ([]pagerduty.User, error) {
 	return listUsersResponse.Users, nil
 }
 
+func (p *PagerDutyClient) GetUserById(id string) (*pagerduty.User, error) {
+	return p.apiClient.GetUser(id, pagerduty.GetUserOptions{})
+}
+
+
 func (p *PagerDutyClient) GetSchedule(scheduleID, startDate, endDate string) (*pagerduty.Schedule, error) {
 	var opts pagerduty.GetScheduleOptions
 	opts.Since = startDate

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -109,6 +109,9 @@ func (c *Configuration) FindRotationUserInfoByID(userID string) (*RotationUser, 
 			return &rotationUser, nil
 		}
 	}
+	if c.DefaultHolidayCalendar == "" { // if you dont specify a default calendar fallback to old behaviour
+		return nil, fmt.Errorf("user id %s not found", userID)
+	}
 
 	user, err := api.Client.GetUserById(userID)
 	if err != nil {
@@ -119,10 +122,11 @@ func (c *Configuration) FindRotationUserInfoByID(userID string) (*RotationUser, 
 		return nil, fmt.Errorf("user id %s not found", userID)
 	}
 
+
 	rotationUser := &RotationUser{
 		UserID:           userID,
 		Name:             user.Name,
-		HolidaysCalendar: c.DefaultHolidayCalendar, // default to uk
+		HolidaysCalendar: c.DefaultHolidayCalendar, // default to config value
 	}
 
 	c.cacheRotationUsers[userID] = rotationUser


### PR DESCRIPTION
It is a pain to have to put every user into your config file.  This change allows you to default users to a calendar if they are not specified in your config file.