### PR TITLE
Extend report to consider users across different timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ rotationInfo:
   dailyRotationStartsAt: 8
   checkRotationChangeEvery: 30 # minutes
 
+defaultUserTimezone: Europe/London # default user timezone for users that are in the report but their account has been excluded from PagerDuty
+
 defaultHolidayCalendar: uk # default calendar to use for users not specified in config, allows you to only define users with different calendars. If value not specified then fall back to old behaviour
 
 # Rotation excluded hours by day type

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ schedulesToIgnore:
 
 ## Known limitations
 
-- `list-people` command: the pagination is not implemented (yet)
 - `report` command: no way to specify the output folder/filename for the pdf report
 - `calendars`:
   - there are only 2018 and 2019 uk bank holiday calendars defined

--- a/api/pagerduty.go
+++ b/api/pagerduty.go
@@ -6,8 +6,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 )
 
-var Client *PagerDutyClient
-
 type PdClient interface {
 	ListSchedules(o pagerduty.ListSchedulesOptions) (*pagerduty.ListSchedulesResponse, error)
 	ListServices(o pagerduty.ListServiceOptions) (*pagerduty.ListServiceResponse, error)
@@ -33,13 +31,6 @@ type UserRotaInfo struct {
 }
 
 type ScheduleUserRotationData map[string]*UserRotaInfo
-
-// InitialisePagerDutyAPIClient intentionally kept but will be removed as soon as generate_report.go is covered by tests
-func InitialisePagerDutyAPIClient(authToken string) {
-	Client = &PagerDutyClient{
-		ApiClient: pagerduty.NewClient(authToken),
-	}
-}
 
 func NewPagerDutyAPIClient(authToken string) *PagerDutyClient {
 	return &PagerDutyClient{

--- a/api/schedules.go
+++ b/api/schedules.go
@@ -46,7 +46,7 @@ func (p *PagerDutyClient) ListSchedules() ([]*Schedule, error) {
 			scheduleList = append(scheduleList, convertSchedule(&schedule))
 		}
 		more = listSchedulesResponse.More
-		opts.Offset = listSchedulesResponse.Limit
+		opts.Offset += listSchedulesResponse.Limit
 	}
 
 	return scheduleList, nil

--- a/api/users.go
+++ b/api/users.go
@@ -7,11 +7,12 @@ import (
 )
 
 type User struct {
-	ID      string
-	Summary string
-	Name    string
-	Email   string
-	Teams   []Team
+	ID       string
+	Summary  string
+	Name     string
+	Email    string
+	Timezone string
+	Teams    []Team
 }
 
 func (p *PagerDutyClient) ListUsers() ([]*User, error) {
@@ -48,10 +49,11 @@ func convertUser(user *pagerduty.User) *User {
 	}
 
 	return &User{
-		ID:      user.ID,
-		Summary: user.Summary,
-		Name:    user.Name,
-		Email:   user.Email,
-		Teams:   userTeams,
+		ID:       user.ID,
+		Summary:  user.Summary,
+		Name:     user.Name,
+		Email:    user.Email,
+		Timezone: user.Timezone,
+		Teams:    userTeams,
 	}
 }

--- a/api/users.go
+++ b/api/users.go
@@ -17,14 +17,20 @@ type User struct {
 
 func (p *PagerDutyClient) ListUsers() ([]*User, error) {
 	var opts pagerduty.ListUsersOptions
-	pdUserList, err := p.ApiClient.ListUsers(opts)
-	if err != nil {
-		return nil, err
-	}
-
 	var userList []*User
-	for _, user := range pdUserList.Users {
-		userList = append(userList, convertUser(&user))
+
+	more := true
+	for more {
+		listUsersResponse, err := p.ApiClient.ListUsers(opts)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, user := range listUsersResponse.Users {
+			userList = append(userList, convertUser(&user))
+		}
+		more = listUsersResponse.More
+		opts.Offset += listUsersResponse.Limit
 	}
 
 	return userList, nil

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -20,9 +20,10 @@ func Test_GetUserById(t *testing.T) {
 		{
 			name: "Successfully get user by ID",
 			want: User{
-				ID:    "QWERTY",
-				Name:  "John Doe",
-				Email: "john.doe@email.com",
+				ID:       "QWERTY",
+				Name:     "John Doe",
+				Email:    "john.doe@email.com",
+				Timezone: "Europe/London",
 				Teams: []Team{
 					{
 						ID: "QWERTY",
@@ -85,6 +86,7 @@ func Test_GetUserById(t *testing.T) {
 			assert.Equal(t, tt.want.ID, user.ID)
 			assert.Equal(t, tt.want.Name, user.Name)
 			assert.Equal(t, tt.want.Email, user.Email)
+			assert.Equal(t, tt.want.Timezone, user.Timezone)
 			assert.Equal(t, tt.want.Teams[0].ID, user.Teams[0].ID)
 		})
 	}
@@ -146,9 +148,10 @@ func Test_ListUsers(t *testing.T) {
 			},
 			want: []*User{
 				{
-					ID:    "QWERTY",
-					Name:  "John Doe",
-					Email: "john.doe@email.com",
+					ID:       "QWERTY",
+					Name:     "John Doe",
+					Email:    "john.doe@email.com",
+					Timezone: "Europe/London",
 					Teams: []Team{
 						{
 							ID: "QWERTY",
@@ -156,9 +159,10 @@ func Test_ListUsers(t *testing.T) {
 					},
 				},
 				{
-					ID:    "QWERTY2",
-					Name:  "Jane Doe",
-					Email: "jane.doe@email.com",
+					ID:       "QWERTY2",
+					Name:     "Jane Doe",
+					Email:    "jane.doe@email.com",
+					Timezone: "Europe/London",
 					Teams: []Team{
 						{
 							ID: "QWERTY2",
@@ -190,6 +194,7 @@ func Test_ListUsers(t *testing.T) {
 				assert.Equal(t, wantUser.ID, userList[i].ID)
 				assert.Equal(t, wantUser.Name, userList[i].Name)
 				assert.Equal(t, wantUser.Email, userList[i].Email)
+				assert.Equal(t, wantUser.Timezone, userList[i].Timezone)
 				assert.Equal(t, wantUser.Teams[0].ID, userList[i].Teams[0].ID)
 			}
 

--- a/cmd/generate_report.go
+++ b/cmd/generate_report.go
@@ -377,9 +377,9 @@ func (pd *pagerDutyClient) generateScheduleData(scheduleInfo *api.ScheduleInfo, 
 				log.Fatal("failed to convert timezone")
 			}
 
-			for currentDate.Before(period.End) {
+			for currentLocalDate.Before(period.End) {
 				updateDataForDate(&userCalendar, scheduleUserData, currentMonth, currentLocalDate)
-				currentDate = currentDate.Add(time.Minute * time.Duration(Config.RotationInfo.CheckRotationChangeEvery))
+				currentLocalDate = currentLocalDate.Add(time.Minute * time.Duration(Config.RotationInfo.CheckRotationChangeEvery))
 			}
 		}
 

--- a/cmd/generate_report.go
+++ b/cmd/generate_report.go
@@ -449,7 +449,7 @@ func updateDataForDate(calendar *configuration.BHCalendar, data *report.Schedule
 		}
 	} else {
 		if calendar.IsDateBankHoliday(date) {
-			excludedHours, _ := Config.FindRotationExcludedHoursByDay("bankholiday")
+			excludedHours := Config.FindRotationExcludedHoursByDay("bankholiday")
 			if excludedHours == nil {
 				//fmt.Printf("%s - Month: %d, time: %v -- bank holiday\n", data.Name, currentMonth, date)
 				data.NumBankHolidaysHours += 0.5
@@ -461,7 +461,7 @@ func updateDataForDate(calendar *configuration.BHCalendar, data *report.Schedule
 				data.NumBankHolidaysHours += 0.5
 			}
 		} else if calendar.IsWeekend(date) {
-			excludedHours, _ := Config.FindRotationExcludedHoursByDay("weekend")
+			excludedHours := Config.FindRotationExcludedHoursByDay("weekend")
 			if excludedHours == nil {
 				//fmt.Printf("%s - Month: %d, time: %v -- weekend\n", data.Name, currentMonth, date)
 				data.NumWeekendHours += 0.5
@@ -473,7 +473,7 @@ func updateDataForDate(calendar *configuration.BHCalendar, data *report.Schedule
 				data.NumWeekendHours += 0.5
 			}
 		} else {
-			excludedHours, _ := Config.FindRotationExcludedHoursByDay("weekday")
+			excludedHours := Config.FindRotationExcludedHoursByDay("weekday")
 			if excludedHours == nil {
 				//fmt.Printf("%s - Month: %d, time: %v -- weekday\n", data.Name, currentMonth, date)
 				data.NumWorkHours += 0.5

--- a/cmd/generate_report.go
+++ b/cmd/generate_report.go
@@ -342,7 +342,7 @@ func (pd *pagerDutyClient) generateScheduleData(scheduleInfo *api.ScheduleInfo, 
 	}
 
 	for userID, userRotaInfo := range usersRotationData {
-		rotationUserConfig, err := Config.FindRotationUserInfoByID(userID, userRotaInfo.Name)
+		rotationUserConfig, err := Config.FindRotationUserInfoByID(userID)
 		if err != nil {
 			log.Println("Error:", err)
 			continue

--- a/cmd/generate_report.go
+++ b/cmd/generate_report.go
@@ -19,7 +19,10 @@ var (
 		Short: "generates the report(s) for the given schedule(s) id(s)",
 		Long:  "Generates the report of the given list of schedules or all (except the ignored ones configured in yml)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pd := &pagerDutyClient{client: api.NewPagerDutyAPIClient(Config.PdAuthToken)}
+			pd := &pagerDutyClient{
+				client:              api.NewPagerDutyAPIClient(Config.PdAuthToken),
+				defaultUserTimezone: Config.DefaultUserTimezone,
+			}
 			return pd.generateReport()
 		},
 	}
@@ -422,7 +425,7 @@ func (pd *pagerDutyClient) getUserTimezone(userID string) (string, error) {
 	}
 
 	if timezone == "" {
-		return "", fmt.Errorf("failed to get user with id %s timezone", userID)
+		timezone = pd.defaultUserTimezone
 	}
 
 	return timezone, nil

--- a/cmd/generate_report.go
+++ b/cmd/generate_report.go
@@ -340,7 +340,7 @@ func generateScheduleData(scheduleInfo *api.ScheduleInfo, usersRotationData api.
 	}
 
 	for userID, userRotaInfo := range usersRotationData {
-		rotationUserConfig, err := Config.FindRotationUserInfoByID(userID)
+		rotationUserConfig, err := Config.FindRotationUserInfoByID(userID, userRotaInfo.Name)
 		if err != nil {
 			log.Println("Error:", err)
 			continue

--- a/cmd/generate_report_test.go
+++ b/cmd/generate_report_test.go
@@ -158,15 +158,15 @@ func Test_pagerDutyClient_convertToUserLocalTimezone(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name:         "Successfully converts schedule BST date to user's EDT local date",
-			scheduleDate: "01 Sep 22 17:00 BST",
+			name:         "Successfully converts schedule GMT date to user's EDT local date",
+			scheduleDate: "01 Sep 22 14:00 GMT",
 			cachedUsers: []*api.User{
 				{
 					ID:       "USER_ID",
 					Timezone: "America/New_York",
 				},
 			},
-			want:    "01 Sep 22 12:00 DST",
+			want:    "01 Sep 22 10:00 EDT",
 			wantErr: false,
 		},
 		{

--- a/cmd/generate_report_test.go
+++ b/cmd/generate_report_test.go
@@ -166,7 +166,7 @@ func Test_pagerDutyClient_convertToUserLocalTimezone(t *testing.T) {
 					Timezone: "America/New_York",
 				},
 			},
-			want:    "01 Sep 22 12:00 EDT",
+			want:    "01 Sep 22 12:00 EST",
 			wantErr: false,
 		},
 		{

--- a/cmd/generate_report_test.go
+++ b/cmd/generate_report_test.go
@@ -166,7 +166,7 @@ func Test_pagerDutyClient_convertToUserLocalTimezone(t *testing.T) {
 					Timezone: "America/New_York",
 				},
 			},
-			want:    "01 Sep 22 12:00 EST",
+			want:    "01 Sep 22 12:00 DST",
 			wantErr: false,
 		},
 		{

--- a/cmd/generate_report_test.go
+++ b/cmd/generate_report_test.go
@@ -69,11 +69,12 @@ func Test_pagerDutyClient_loadUsersInMemoryCache(t *testing.T) {
 
 func Test_pagerDutyClient_getUserTimezone(t *testing.T) {
 	tests := []struct {
-		name        string
-		cachedUsers []*api.User
-		mockSetup   func(mock *clientMock)
-		want        string
-		wantErr     bool
+		name                string
+		cachedUsers         []*api.User
+		defaultUserTimezone string
+		mockSetup           func(mock *clientMock)
+		want                string
+		wantErr             bool
 	}{
 		{
 			name: "Successfully find the user timezone",
@@ -87,24 +88,26 @@ func Test_pagerDutyClient_getUserTimezone(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "User with empty timezone will fail to return timezone",
+			name: "User with empty timezone will receive default configured timezone",
 			cachedUsers: []*api.User{
 				{
 					ID: "USER_ID",
 				},
 			},
-			want:    "Europe/London",
-			wantErr: true,
+			defaultUserTimezone: "Europe/London",
+			want:                "Europe/London",
+			wantErr:             false,
 		},
 		{
-			name: "User not cached will fail to return timezone",
+			name: "User not cached will receive default configured timezone",
 			cachedUsers: []*api.User{
 				{
 					ID: "NOT_THE_USER_ID",
 				},
 			},
-			want:    "Europe/London",
-			wantErr: true,
+			defaultUserTimezone: "America/Sao_Paulo",
+			want:                "America/Sao_Paulo",
+			wantErr:             false,
 		},
 		{
 			name: "If user not cached it will load users in cache and successfully return timezone",
@@ -124,7 +127,11 @@ func Test_pagerDutyClient_getUserTimezone(t *testing.T) {
 				tt.mockSetup(mockedClient)
 			}
 
-			pd := pagerDutyClient{client: mockedClient, cachedUsers: tt.cachedUsers}
+			pd := pagerDutyClient{
+				client:              mockedClient,
+				cachedUsers:         tt.cachedUsers,
+				defaultUserTimezone: tt.defaultUserTimezone,
+			}
 
 			got, err := pd.getUserTimezone("USER_ID")
 			mockedClient.AssertExpectations(t)

--- a/cmd/generate_report_test.go
+++ b/cmd/generate_report_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/form3tech-oss/go-pagerduty-oncall-report/api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_pagerDutyClient_loadUsersInMemoryCache(t *testing.T) {
+	users := []*api.User{
+		{
+			ID:   "1",
+			Name: "John Doe",
+		},
+		{
+			ID:   "2",
+			Name: "Mary Jane",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		mockSetup func(*clientMock)
+		want      []*api.User
+		wantErr   bool
+	}{
+		{
+			name: "Successfully load users in memory",
+			mockSetup: func(mock *clientMock) {
+				mock.On("ListUsers").Once().Return(users, nil)
+			},
+			want:    users,
+			wantErr: false,
+		},
+		{
+			name: "Failed load users in memory",
+			mockSetup: func(mock *clientMock) {
+				mock.On("ListUsers").Once().Return(nil, errors.New("failed"))
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockedClient := &clientMock{}
+			if tt.mockSetup != nil {
+				tt.mockSetup(mockedClient)
+			}
+
+			pd := pagerDutyClient{client: mockedClient}
+			err := pd.loadUsersInMemoryCache()
+			mockedClient.AssertExpectations(t)
+
+			if tt.wantErr == true {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, users, pd.cachedUsers)
+		})
+	}
+}
+
+func Test_pagerDutyClient_getUserTimezone(t *testing.T) {
+	tests := []struct {
+		name        string
+		cachedUsers []*api.User
+		mockSetup   func(mock *clientMock)
+		want        string
+		wantErr     bool
+	}{
+		{
+			name: "Successfully find the user timezone",
+			cachedUsers: []*api.User{
+				{
+					ID:       "USER_ID",
+					Timezone: "Europe/London",
+				},
+			},
+			want:    "Europe/London",
+			wantErr: false,
+		},
+		{
+			name: "User with empty timezone will fail to return timezone",
+			cachedUsers: []*api.User{
+				{
+					ID: "USER_ID",
+				},
+			},
+			want:    "Europe/London",
+			wantErr: true,
+		},
+		{
+			name: "User not cached will fail to return timezone",
+			cachedUsers: []*api.User{
+				{
+					ID: "NOT_THE_USER_ID",
+				},
+			},
+			want:    "Europe/London",
+			wantErr: true,
+		},
+		{
+			name: "If user not cached it will load users in cache and successfully return timezone",
+			mockSetup: func(mock *clientMock) {
+				mock.On("ListUsers").Once().Return([]*api.User{
+					{ID: "USER_ID", Timezone: "Europe/London"},
+				}, nil)
+			},
+			want:    "Europe/London",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockedClient := &clientMock{}
+			if tt.mockSetup != nil {
+				tt.mockSetup(mockedClient)
+			}
+
+			pd := pagerDutyClient{client: mockedClient, cachedUsers: tt.cachedUsers}
+
+			got, err := pd.getUserTimezone("USER_ID")
+			mockedClient.AssertExpectations(t)
+
+			if tt.wantErr == true {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/mocks_test.go
+++ b/cmd/mocks_test.go
@@ -13,6 +13,29 @@ type clientMock struct {
 	mock.Mock
 }
 
+// GetSchedule provides a mock function with given fields: scheduleID, startDate, endDate
+func (_m *clientMock) GetSchedule(scheduleID string, startDate string, endDate string) (*api.Schedule, error) {
+	ret := _m.Called(scheduleID, startDate, endDate)
+
+	var r0 *api.Schedule
+	if rf, ok := ret.Get(0).(func(string, string, string) *api.Schedule); ok {
+		r0 = rf(scheduleID, startDate, endDate)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.Schedule)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(scheduleID, startDate, endDate)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListUsers provides a mock function with given fields:
 func (_m *clientMock) ListUsers() ([]*api.User, error) {
 	ret := _m.Called()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,8 @@ type pagerDutyClient struct {
 	client client
 
 	cachedUsers []*api.User
+
+	defaultUserTimezone string
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ type client interface {
 	ListTeams() ([]*api.Team, error)
 	ListServices(string) ([]*api.Service, error)
 	ListSchedules() ([]*api.Schedule, error)
+	GetSchedule(scheduleID, startDate, endDate string) (*api.Schedule, error)
 }
 
 type pagerDutyClient struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,8 @@ type client interface {
 
 type pagerDutyClient struct {
 	client client
+
+	cachedUsers []*api.User
 }
 
 func init() {
@@ -67,8 +69,6 @@ func initConfig() {
 	if err != nil {
 		log.Fatalf("%v, %#v", err, Config)
 	}
-
-	api.InitialisePagerDutyAPIClient(Config.PdAuthToken)
 }
 
 var rootCmd = &cobra.Command{

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -98,7 +98,7 @@ func (c *Configuration) FindRotationExcludedHoursByDay(dayType string) (*Rotatio
 	return nil, fmt.Errorf("day type %s not found", dayType)
 }
 
-func (c *Configuration) FindRotationUserInfoByID(userID, userName string) (*RotationUser, error) {
+func (c *Configuration) FindRotationUserInfoByID(userID string) (*RotationUser, error) {
 	if rotationUser, ok := c.cacheRotationUsers[userID]; ok {
 		return rotationUser, nil
 	}
@@ -119,7 +119,7 @@ func (c *Configuration) FindRotationUserInfoByID(userID, userName string) (*Rota
 	}
 
 	c.cacheRotationUsers[userID] = rotationUser
-	log.Printf("defaulting user %s id: %s to %s\n", userName, userID, c.DefaultHolidayCalendar)
+	log.Printf("defaulting user with id: %s to %s\n", userID, c.DefaultHolidayCalendar)
 
 	return rotationUser, nil
 }

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -46,6 +46,7 @@ type ScheduleTimeRange struct {
 type Configuration struct {
 	PdAuthToken                string
 	DefaultHolidayCalendar     string
+	DefaultUserTimezone        string
 	ReportTimeRange            ReportTimeRange
 	RotationInfo               RotationInfo
 	RotationExcludedHours      []RotationExcludedHoursDay

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -83,19 +83,19 @@ func (c *Configuration) FindPriceByDay(dayType string) (*int, error) {
 	return nil, fmt.Errorf("day type %s not found", dayType)
 }
 
-func (c *Configuration) FindRotationExcludedHoursByDay(dayType string) (*RotationExcludedHoursDay, error) {
+func (c *Configuration) FindRotationExcludedHoursByDay(dayType string) *RotationExcludedHoursDay {
 	if excludedInfo, ok := c.cacheExcludedByDay[dayType]; ok {
-		return excludedInfo, nil
+		return excludedInfo
 	}
 
 	for _, rotationExcludedHours := range c.RotationExcludedHours {
 		if rotationExcludedHours.Day == dayType {
 			c.cacheExcludedByDay[rotationExcludedHours.Day] = &rotationExcludedHours
-			return &rotationExcludedHours, nil
+			return &rotationExcludedHours
 		}
 	}
 
-	return nil, fmt.Errorf("day type %s not found", dayType)
+	return nil
 }
 
 func (c *Configuration) FindRotationUserInfoByID(userID string) (*RotationUser, error) {

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -3,8 +3,6 @@ package configuration
 import (
 	"fmt"
 	"log"
-
-	"github.com/form3tech-oss/go-pagerduty-oncall-report/api"
 )
 
 type RotationUser struct {
@@ -99,7 +97,7 @@ func (c *Configuration) FindRotationExcludedHoursByDay(dayType string) (*Rotatio
 	return nil, fmt.Errorf("day type %s not found", dayType)
 }
 
-func (c *Configuration) FindRotationUserInfoByID(userID string) (*RotationUser, error) {
+func (c *Configuration) FindRotationUserInfoByID(userID, userName string) (*RotationUser, error) {
 	if rotationUser, ok := c.cacheRotationUsers[userID]; ok {
 		return rotationUser, nil
 	}
@@ -114,23 +112,13 @@ func (c *Configuration) FindRotationUserInfoByID(userID string) (*RotationUser, 
 		return nil, fmt.Errorf("user id %s not found", userID)
 	}
 
-	user, err := api.Client.GetUserById(userID)
-	if err != nil {
-		return nil, fmt.Errorf("could not find user from pagerduty api, err: %v", err)
-	}
-
-	if user == nil {
-		return nil, fmt.Errorf("user id %s not found", userID)
-	}
-
 	rotationUser := &RotationUser{
 		UserID:           userID,
-		Name:             user.Name,
 		HolidaysCalendar: c.DefaultHolidayCalendar, // default to config value
 	}
 
 	c.cacheRotationUsers[userID] = rotationUser
-	log.Printf("defaulting user %s id: %s to %s\n", user.Name, userID, c.DefaultHolidayCalendar)
+	log.Printf("defaulting user %s id: %s to %s\n", userName, userID, c.DefaultHolidayCalendar)
 
 	return rotationUser, nil
 }

--- a/configuration/price.go
+++ b/configuration/price.go
@@ -15,7 +15,7 @@ func (c *Configuration) GetPricesInfo() (*PricesInfo, error) {
 		return nil, err
 	}
 	excludedWeekDayHoursAmount := 0
-	excludedHours, _ := c.FindRotationExcludedHoursByDay("weekday")
+	excludedHours := c.FindRotationExcludedHoursByDay("weekday")
 	if excludedHours != nil {
 		excludedWeekDayHoursAmount = excludedHours.ExcludedEndsAt - excludedHours.ExcludedStartsAt
 	}
@@ -26,7 +26,7 @@ func (c *Configuration) GetPricesInfo() (*PricesInfo, error) {
 		return nil, err
 	}
 	excludedWeekendDayHoursAmount := 0
-	excludedHours, _ = c.FindRotationExcludedHoursByDay("weekend")
+	excludedHours = c.FindRotationExcludedHoursByDay("weekend")
 	if excludedHours != nil {
 		excludedWeekendDayHoursAmount = excludedHours.ExcludedEndsAt - excludedHours.ExcludedStartsAt
 	}
@@ -37,7 +37,7 @@ func (c *Configuration) GetPricesInfo() (*PricesInfo, error) {
 		return nil, err
 	}
 	excludedBhDayHoursAmount := 0
-	excludedHours, _ = c.FindRotationExcludedHoursByDay("bankholiday")
+	excludedHours = c.FindRotationExcludedHoursByDay("bankholiday")
 	if excludedHours != nil {
 		excludedBhDayHoursAmount = excludedHours.ExcludedEndsAt - excludedHours.ExcludedStartsAt
 	}

--- a/configuration/price.go
+++ b/configuration/price.go
@@ -1,0 +1,54 @@
+package configuration
+
+type PricesInfo struct {
+	WeekDayHourlyPrice    float32
+	HoursWeekDay          int
+	WeekendDayHourlyPrice float32
+	HoursWeekendDay       int
+	BhDayHourlyPrice      float32
+	HoursBhDay            int
+}
+
+func (c *Configuration) GetPricesInfo() (*PricesInfo, error) {
+	weekDayPrice, err := c.FindPriceByDay("weekday")
+	if err != nil {
+		return nil, err
+	}
+	excludedWeekDayHoursAmount := 0
+	excludedHours, _ := c.FindRotationExcludedHoursByDay("weekday")
+	if excludedHours != nil {
+		excludedWeekDayHoursAmount = excludedHours.ExcludedEndsAt - excludedHours.ExcludedStartsAt
+	}
+	weekDayWorkingHours := 24 - excludedWeekDayHoursAmount
+
+	weekendDayPrice, err := c.FindPriceByDay("weekend")
+	if err != nil {
+		return nil, err
+	}
+	excludedWeekendDayHoursAmount := 0
+	excludedHours, _ = c.FindRotationExcludedHoursByDay("weekend")
+	if excludedHours != nil {
+		excludedWeekendDayHoursAmount = excludedHours.ExcludedEndsAt - excludedHours.ExcludedStartsAt
+	}
+	weekendDayWorkingHours := 24 - excludedWeekendDayHoursAmount
+
+	bhDayPrice, err := c.FindPriceByDay("bankholiday")
+	if err != nil {
+		return nil, err
+	}
+	excludedBhDayHoursAmount := 0
+	excludedHours, _ = c.FindRotationExcludedHoursByDay("bankholiday")
+	if excludedHours != nil {
+		excludedBhDayHoursAmount = excludedHours.ExcludedEndsAt - excludedHours.ExcludedStartsAt
+	}
+	bhWorkingHours := 24 - excludedBhDayHoursAmount
+
+	return &PricesInfo{
+		WeekDayHourlyPrice:    float32(*weekDayPrice) / float32(weekDayWorkingHours),
+		HoursWeekDay:          weekDayWorkingHours,
+		WeekendDayHourlyPrice: float32(*weekendDayPrice) / float32(weekendDayWorkingHours),
+		HoursWeekendDay:       weekendDayWorkingHours,
+		BhDayHourlyPrice:      float32(*bhDayPrice) / float32(bhWorkingHours),
+		HoursBhDay:            bhWorkingHours,
+	}, nil
+}

--- a/test/stages/config_stage.go
+++ b/test/stages/config_stage.go
@@ -1,11 +1,11 @@
 package stages
 
 import (
+	"bytes"
 	"testing"
 
-	"bytes"
-
 	"github.com/form3tech-oss/go-pagerduty-oncall-report/configuration"
+
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -121,12 +121,12 @@ func (s *ConfigStage) ANonExistingPriceIsRequested() *ConfigStage {
 }
 
 func (s *ConfigStage) AnExistingRotationInfoIsRequested() *ConfigStage {
-	s.mapValue, s.mapError = s.config.FindRotationUserInfoByID("ABCDEF1")
+	s.mapValue, s.mapError = s.config.FindRotationUserInfoByID("ABCDEF1", "NAME")
 	return s
 }
 
 func (s *ConfigStage) ANonExistingRotationInfoIsRequested() *ConfigStage {
-	s.mapValue, s.mapError = s.config.FindRotationUserInfoByID("NONE")
+	s.mapValue, s.mapError = s.config.FindRotationUserInfoByID("NONE", "NAME")
 	return s
 }
 

--- a/test/stages/config_stage.go
+++ b/test/stages/config_stage.go
@@ -121,12 +121,12 @@ func (s *ConfigStage) ANonExistingPriceIsRequested() *ConfigStage {
 }
 
 func (s *ConfigStage) AnExistingRotationInfoIsRequested() *ConfigStage {
-	s.mapValue, s.mapError = s.config.FindRotationUserInfoByID("ABCDEF1", "NAME")
+	s.mapValue, s.mapError = s.config.FindRotationUserInfoByID("ABCDEF1")
 	return s
 }
 
 func (s *ConfigStage) ANonExistingRotationInfoIsRequested() *ConfigStage {
-	s.mapValue, s.mapError = s.config.FindRotationUserInfoByID("NONE", "NAME")
+	s.mapValue, s.mapError = s.config.FindRotationUserInfoByID("NONE")
 	return s
 }
 


### PR DESCRIPTION
## Context

This PR introduces support for calculating the remuneration of on-call employees considering their timezones.

It is now possible to have a single more complex schedule with engineers located in different parts of the world and exclude the work schedule based on their timezones.

This featured required to add a new parameter (`defaultUserTimezone`) to define the default user timezone when not found in the PagerDuty API. This is to cover an edge case when there is a user listed in a PagerDuty schedule but for some reason was removed from the PagerDuty (i.e. left the company).

## Proof of Work

To exemplify one schedule will be created having the following parameters/configurations:
- Price per weekday: £16 (£1 per hour) | weekend/holiday: £32 (£2 per hour) 
- UK based engineer working from 09:00BST to 17:00BST
- Canadian based engineer working from 17:00BST (12:00EDT UTC -4) to 22:00BST (17:00EDT UTC -4)  
- <img width="1343" alt="Schedule layers" src="https://user-images.githubusercontent.com/100683264/189146767-fc507d21-573a-4f86-b91b-f7ae5bbb66a6.png">
- The report will be generated for 2 weeks, from 12th of September until 23rd of September, having the following schedule:
- <img width="947" alt="schedule" src="https://user-images.githubusercontent.com/100683264/189147581-455b40af-c16a-43c6-80ac-b9a2a9458bf1.png">

From the previous version without the timezone feature, the report generated will look like the image below:
- <img width="967" alt="old report" src="https://user-images.githubusercontent.com/100683264/189149339-2db7234e-3f32-495c-9663-3a345541252a.png">

The new version of the generated report:
- <img width="971" alt="new report" src="https://user-images.githubusercontent.com/100683264/189149672-621cd55a-af39-480d-8935-0bacaf968c29.png">

## Extra mile
- Small refactoring removing the API package dependency completely
- Fix known issue regarding users list command using pagination
  - This was required to avoid hundreds/thousands of API calls to fetch the user timezone, storing the user data in memory cache 
- Fixed a silent bug in the schedules list pagination that appears only after having 50+ schedules.