### PR TITLE
PagerDuty auth token configuration from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,15 @@ Use "pd-report [command] --help" for more information about a command.
 
 ## Configuration
 
-The configuration must be a `.yml` file (specified by the `--config` flag) with the following content:
+To run you must configure the PagerDuty token in your environment variables
+
+```shell
+export PD_AUTH_TOKEN=<YourSecretTokenHere>
+```
+
+The configuration of the application parameters must be in the `yaml` file (specified by the `--config` flag) with the following content:
 
 ```yml
-# PagerDuty auth token
-pdAuthToken: 12345
-
 # Explicitly set report time range (RFC822)
 reportTimeRange:
   start: 01 Jan 20 00:00 UTC

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,11 @@ func initConfig() {
 		log.Fatal("Can't read config: ", err)
 	}
 
+	viper.AutomaticEnv()
+	if err := viper.BindEnv("PD_AUTH_TOKEN"); err != nil {
+		log.Fatal(err)
+	}
+
 	Config = configuration.New()
 	err := viper.Unmarshal(&Config)
 	if err != nil {

--- a/configuration/config.go
+++ b/configuration/config.go
@@ -44,7 +44,8 @@ type ScheduleTimeRange struct {
 }
 
 type Configuration struct {
-	PdAuthToken                string
+	PdAuthToken string `mapstructure:"PD_AUTH_TOKEN"` // loads from env variable
+
 	DefaultHolidayCalendar     string
 	DefaultUserTimezone        string
 	ReportTimeRange            ReportTimeRange


### PR DESCRIPTION
## Context

This PR introduces a new configuration format for the PagerDuty token since it's a sensitive data which cannot stay in the plain text. 

## Proof of work

Manually tested following the steps:

1. Removing the pdAuthToken from the `yaml` configuration file
2. Executing the following command:
```shell
PD_AUTH_TOKEN=secretToken ./pd-report report --config ./.pd-report-config-test.yaml -o pdf -d $HOME
```

Report was generated with success and data was verified. 