### PR TITLE
Updates UK calendar for 2022

### DIFF
--- a/_assets/calendars/holidays_calendar.uk.2022.yml
+++ b/_assets/calendars/holidays_calendar.uk.2022.yml
@@ -14,6 +14,8 @@
   date: 03/06/2022
 - title: "Summer"
   date: 29/08/2022
+- title: "State Funeral of Queen Elizabeth II"
+  date: 19/09/2022
 - title: "Christmas Day"
   date: 26/12/2021
 - title: "Boxing Day"


### PR DESCRIPTION
Adds missing holiday for State Funeral of Queen Elizabeth II, 19.09, in the UK calendar for 2022