### PR TITLE
fix: Set proper year in Christmas bank holidays dates in UK

### DIFF
--- a/_assets/calendars/holidays_calendar.uk.2022.yml
+++ b/_assets/calendars/holidays_calendar.uk.2022.yml
@@ -17,6 +17,6 @@
 - title: "State Funeral of Queen Elizabeth II"
   date: 19/09/2022
 - title: "Christmas Day"
-  date: 26/12/2021
+  date: 26/12/2022
 - title: "Boxing Day"
-  date: 27/12/2021
+  date: 27/12/2022


### PR DESCRIPTION
UK Christmas bank holidays used 2021 date instead of 2022.
This change sets year to 2022.
