### PR TITLE
bug: fixed override schedules are included when outside of time range

### DIFF
--- a/cmd/generate_report.go
+++ b/cmd/generate_report.go
@@ -120,17 +120,22 @@ func (pd *pagerDutyClient) processArguments() []Schedule {
 				}
 
 				var thisEndDate time.Time
+				isOveridden := false
 				if _, ok := endOverrides[schedule.ID]; ok {
 					thisEndDate = endOverrides[schedule.ID]
+					isOveridden = true
 				} else {
 					thisEndDate = defaultEndDate
 				}
 
-				schedules = append(schedules, Schedule{
-					id:        schedule.ID,
-					startDate: thisStartDate,
-					endDate:   thisEndDate,
-				})
+				// Ignore this schedule if its overridden and the dates are not in our report range
+				if !isOveridden || !defaultStartDate.After(thisEndDate) {
+					schedules = append(schedules, Schedule{
+						id:        schedule.ID,
+						startDate: thisStartDate,
+						endDate:   thisEndDate,
+					})
+				}
 
 				log.Printf("[%s] defaultStartDate: %s, defaultEndDate: %s", schedule.ID, thisStartDate, thisEndDate)
 


### PR DESCRIPTION

When using the `scheduleTimeRangeOverrides` configuration option the schedule was being included even if the scheduledTimeOverride was outside of the report time window.

With this fix you can get the functionality of only including a schedule in a certain window.  So for example if you have a schedule that is active every weekend but you only want to pay for one weekend a month when you have a special event you can set up the configuration:

```
scheduleTimeRangeOverrides:
  - id: 123
    start: 15 Jul 23 07:00 BST
    end: 16 Jul 23 19:00 BST
```

This will mean that only the weekend of 15/16 July will be paid for the schedule, even though in PagerDuty the schedule will repeat every weekend, as there is no way to do a monthly schedule.