### PR TITLE
fix: `ExcludedStartsAt` incorporated into excludedHours for weekend/bank holiday

### DIFF
--- a/cmd/generate_report.go
+++ b/cmd/generate_report.go
@@ -487,7 +487,7 @@ func updateDataForDate(calendar *configuration.BHCalendar, data *report.Schedule
 				return
 			}
 
-			if date.Hour() < excludedHours.ExcludedEndsAt && date.Hour() >= excludedHours.ExcludedEndsAt {
+			if date.Hour() < excludedHours.ExcludedStartsAt && date.Hour() >= excludedHours.ExcludedEndsAt {
 				//fmt.Printf("%s - Month: %d, time: %v -- bank holiday non excluded hours\n", data.Name, currentMonth, date)
 				data.NumBankHolidaysHours += 0.5
 			}
@@ -499,7 +499,7 @@ func updateDataForDate(calendar *configuration.BHCalendar, data *report.Schedule
 				return
 			}
 
-			if date.Hour() < excludedHours.ExcludedEndsAt && date.Hour() >= excludedHours.ExcludedEndsAt {
+			if date.Hour() < excludedHours.ExcludedStartsAt && date.Hour() >= excludedHours.ExcludedEndsAt {
 				//fmt.Printf("%s - Month: %d, time: %v -- weekend non excluded hours\n", data.Name, currentMonth, date)
 				data.NumWeekendHours += 0.5
 			}


### PR DESCRIPTION
As reported via https://github.com/form3tech-oss/go-pagerduty-oncall-report/issues/33.

This PR addresses a bug in regards to the handling of `excludedHours` for bank holidays and weekends. Previously, the check for non-excluded hours did not properly account for the ExcludedStartsAt time, which could lead to incorrect hour calculations.

## Changes

Added a condition to check if the current hour is less than ExcludedStartsAt or greater than or equal to ExcludedEndsAt. This aligns the logic with how weekdays are handled.

These changes ensure that the code correctly handles excluded hours for both bank holidays and weekends, similar to how it was already done for weekdays.