### PR TITLE
fix: Bank holiday and weekend exclusion boolean check

### DIFF
--- a/cmd/generate_report.go
+++ b/cmd/generate_report.go
@@ -487,7 +487,7 @@ func updateDataForDate(calendar *configuration.BHCalendar, data *report.Schedule
 				return
 			}
 
-			if date.Hour() < excludedHours.ExcludedStartsAt && date.Hour() >= excludedHours.ExcludedEndsAt {
+			if date.Hour() < excludedHours.ExcludedStartsAt || date.Hour() >= excludedHours.ExcludedEndsAt {
 				//fmt.Printf("%s - Month: %d, time: %v -- bank holiday non excluded hours\n", data.Name, currentMonth, date)
 				data.NumBankHolidaysHours += 0.5
 			}
@@ -499,7 +499,7 @@ func updateDataForDate(calendar *configuration.BHCalendar, data *report.Schedule
 				return
 			}
 
-			if date.Hour() < excludedHours.ExcludedStartsAt && date.Hour() >= excludedHours.ExcludedEndsAt {
+			if date.Hour() < excludedHours.ExcludedStartsAt || date.Hour() >= excludedHours.ExcludedEndsAt {
 				//fmt.Printf("%s - Month: %d, time: %v -- weekend non excluded hours\n", data.Name, currentMonth, date)
 				data.NumWeekendHours += 0.5
 			}


### PR DESCRIPTION
PR #67 aimed to fix the exclusion logic handling on bank holidays and weekends by copying the code from weekdays. However the boolean was left as an `&&`, meaning the `if` statement would never match as the current local hour won't be simultaneously earlier than the start hour and later then the end hour.